### PR TITLE
Fix very short lines in P within LI

### DIFF
--- a/assets/scss/vendor/tufte.scss
+++ b/assets/scss/vendor/tufte.scss
@@ -184,7 +184,8 @@ ul {
     -webkit-padding-end: 5%;
 }
 
-li  ul {
+li ul,
+li p {
     width: 100%;
 }
 


### PR DESCRIPTION
#47 fixed very short lines in lists nested within lists.  This extends that (hopefully) to when list items consist of paragraphs.